### PR TITLE
install query-tee not grafana-agent in repository tests

### DIFF
--- a/roles/repository/molecule/debian/verify.yml
+++ b/roles/repository/molecule/debian/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Install grafana-agent
+    - name: Install query-tee
       ansible.builtin.apt:
-        name: grafana-agent
+        name: query-tee
         state: present

--- a/roles/repository/molecule/redhat/verify.yml
+++ b/roles/repository/molecule/redhat/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Install grafana-agent
+    - name: Install query-tee
       ansible.builtin.dnf:
-        name: grafana-agent
+        name: query-tee
         state: present

--- a/roles/repository/molecule/suse/verify.yml
+++ b/roles/repository/molecule/suse/verify.yml
@@ -3,7 +3,7 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Install grafana-agent
+    - name: Install query-tee
       ansible.builtin.package:
-        name: grafana-agent
+        name: query-tee
         state: present


### PR DESCRIPTION
the package is MUCH smaller (<10MB vs 100+) and thus installs faster
