### PR TITLE
detect tests from the roles folder, not collections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: pip install molecule molecule-plugins pytest pytest-ansible
       - name: Run tests
-        run: pytest -vv --molecule collections/
+        run: pytest -vv --molecule roles/
 
   ansible-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
the later is generated by pytest-ansible and might vanish
